### PR TITLE
Fix the panic caused by the request error

### DIFF
--- a/youtube_chat/src/request.rs
+++ b/youtube_chat/src/request.rs
@@ -28,7 +28,7 @@ pub async fn fetch_chat<'a>(
     let client = reqwest::Client::new();
     let response = client.post(url).json(&body).send().await?;
     let text = response.text().await.unwrap();
-    let json: GetLiveChatResponse = serde_json::from_str(&text).unwrap();
+    let json: GetLiveChatResponse = serde_json::from_str(&text)?;
     Ok(parse_chat_data(json))
 }
 


### PR DESCRIPTION
First of all, thank you for this library!

I found out that youtube may response error request if I use it for a long time.

So I suggest to leave this error to the user because unwrap can cause a panic.

Thanks again!