### PR TITLE
Fix timestamp calculation

### DIFF
--- a/youtube_chat/src/parser.rs
+++ b/youtube_chat/src/parser.rs
@@ -273,8 +273,7 @@ impl Renderer {
                 renderer.message_renderer_base.timestamp_usec.clone()
             }
         };
-        Utc.timestamp_millis_opt(timestamp_usec.parse::<i64>().ok()?)
-            .earliest()
+        Some(Utc.timestamp_nanos(timestamp_usec.parse::<i64>().ok()? * 1000))
     }
 
     fn author_badge(&self) -> Option<Vec<AuthorBadge>> {


### PR DESCRIPTION
Closes #9
 * timestamps seem to be provided as micro secs, but previously interpreted as milli secs. This pull request fix this.